### PR TITLE
fix: facility details "New Case" button position 

### DIFF
--- a/libs/facilities/frontend/domain/src/lib/application/facades/facility-detail.facade.ts
+++ b/libs/facilities/frontend/domain/src/lib/application/facades/facility-detail.facade.ts
@@ -92,7 +92,7 @@ export class FacilityDetailFacade {
 
     private randomEcoScoreFromString(str: string) {
         // exception for the very legitimate waste disposal :D
-        if(str === 'totally legal waste disposal'){
+        if(str === 'Totally legal waste disposal'){
             return 26;
         }
 

--- a/libs/facilities/frontend/view/src/lib/components/facility-detail/facility-detail.page.html
+++ b/libs/facilities/frontend/view/src/lib/components/facility-detail/facility-detail.page.html
@@ -11,11 +11,11 @@
 <ix-content>
 	<div class="details-grid gap-x-6 gap-y-4 pb-32">
 		@if(this.pumpChart(); as pumpChart){
-		<div echarts [options]="pumpChart" [theme]="theme()" style="height: 25rem"></div>
+		    <div echarts [options]="pumpChart" [theme]="theme()" style="height: 25rem"></div>
 		} @if(this.envChart(); as envChart){
-		<div echarts [options]="envChart" [theme]="theme()" style="height: 25rem"></div>
+		    <div echarts [options]="envChart" [theme]="theme()" style="height: 25rem"></div>
 		} @if(this.metricsChart(); as metricsChart){
-		<div echarts [options]="metricsChart" [theme]="theme()" style="height: 25rem"></div>
+		    <div echarts [options]="metricsChart" [theme]="theme()" style="height: 25rem"></div>
 		}
 
 		<ix-card variant="insight" class="h-full w-full p-4">
@@ -59,7 +59,13 @@
 				<ix-typography color="std">
 					{{ getCasesText(facility.cases.length) }}
 				</ix-typography>
-				<div class="flex flex-row justify-between w-full">
+				<div class="flex flex-row-reverse justify-between w-full h-full">
+                    <div class="mt-auto p-2">
+                        <ix-button [routerLink]="['/cases/create',{ facilityId: facility.id }]">
+                            New Case
+                        </ix-button>
+                    </div>
+
 					@if (facility.cases.length > 0) {
 					<div>
 						<div class="flex flex-col pt-2">
@@ -76,12 +82,6 @@
 						}
 					</div>
 					}
-
-					<div class="mt-auto p-2">
-						<ix-button [routerLink]="['/cases/create',{ facilityId: facility.id }]">
-							New Case
-						</ix-button>
-					</div>
 				</div>
 			</ix-card-content>
 		</ix-card>


### PR DESCRIPTION
last small fixes:
- exception for "totally legal waste disposal" stopped because I made the t big
- on facility-detail page the button was not always in the bottom right corner when there are no cases
before: 
![grafik](https://github.com/user-attachments/assets/5114f4d7-c4d4-4f98-b89b-bad614db9624)

after:
![grafik](https://github.com/user-attachments/assets/64a53ebb-ee58-4455-99bb-909b3fac2856)


Signed-off-by: Ingo Sternberg <ingo.sternberg@fau.de>
#243